### PR TITLE
Gauss Cannon change

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8133,7 +8133,7 @@
 			"RailGun2Mk1"
 		],
 		"requiredResearch": [
-			"R-Wpn-Rail-Damage03"
+			"R-Wpn-RailGun02"
 		],
 		"researchPoints": 43200,
 		"researchPower": 450,


### PR DESCRIPTION
required Research: Hardened Rail Dart Mk3 ->Rail Gun

This change will not spoil the balance because Scourge Missile already has all buffs and all artillery is also available (see images below).
Also, this change is necessary because of the 1.5 hour autohost time limit, which means that the gauss cannot reach its full potential in time, and the gun needs to be moved 10 minutes earlier
Moving GC will result in a very acceptable time gap for T4 between Rail Gun and GS of 10 minutes
Because of the GC move, Mass Driver will also move by 10 minutes, which will be a plus for balance because Missile Fortress is so far the best and is available before Mass Driver